### PR TITLE
feat: 박스 수정 화면 퍼블리싱 (#58)

### DIFF
--- a/src/features/wallet/components/BoxEdit.tsx
+++ b/src/features/wallet/components/BoxEdit.tsx
@@ -1,14 +1,151 @@
-import type { Box } from '../types';
+import React, { useEffect, useRef, useState } from 'react';
+import { Switch, type InputRef } from 'antd';
+import Input from '@/components/input/Input';
+import Button from '@/components/button/Button';
+import BoxInput from '@/components/common/BoxInput';
+import Header from '@/components/Header';
+import type { Box } from '@/features/wallet/types';
 
 interface BoxEditProps {
   box: Box;
   onBack: () => void;
-  onSave: () => void;
+  onSave: (updatedBox: {
+    boxName: string;
+    automaticTransfer: boolean;
+    monthlyAmount: number;
+    transferDay: string;
+  }) => void;
 }
 
-const BoxEdit: React.FC<BoxEditProps> = () => {
+const BoxEdit: React.FC<BoxEditProps> = ({ box, onBack, onSave }) => {
+  const [boxName, setBoxName] = useState(box.boxName || box.name || '');
+  const [automaticTransfer, setAutomaticTransfer] = useState(
+    box.automaticTransfer || false
+  );
+  const [monthlyAmount, setMonthlyAmount] = useState(box.monthlyAmount || 0);
+  const [transferDay, setTransferDay] = useState(box.transferDay || '');
+
+  const inputRef = useRef<InputRef>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // 입력값에서 숫자만 추출
+    const rawValue = e.target.value.replace(/[^0-9]/g, '');
+    if (!rawValue) {
+      setMonthlyAmount(0);
+      return;
+    }
+    // 숫자로 변환 후 locale string 적용
+    setMonthlyAmount(Number(rawValue));
+  };
+
+  useEffect(() => {
+    if (automaticTransfer) {
+      inputRef.current?.focus();
+    }
+  }, [automaticTransfer]);
+
+  const handleSave = () => {
+    onSave({
+      boxName,
+      automaticTransfer,
+      monthlyAmount,
+      transferDay,
+    });
+  };
+
   return (
-    <div className="w-full h-full pt-5 px-6">대현오뻐거 갖다 써야지 ~</div>
+    <div className="w-full h-screen flex flex-col">
+      <div className="flex-1 flex flex-col min-h-0">
+        <div className="px-6">
+          <Header onClick={onBack} />
+        </div>
+
+        <div className="flex-1 px-6 overflow-y-auto pb-6">
+          <div className="space-y-6 text-left">
+            <p className="font-hana-regular text-3xl mb-3">
+              <span className="font-hana-bold">박스 별명</span>을 입력해 주세요
+            </p>
+            <Input
+              intent="green"
+              value={boxName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setBoxName(e.target.value)
+              }
+            />
+
+            <div className="flex items-center gap-15 w-full my-10">
+              <span className="font-hana-regular text-3xl">
+                <span className="font-hana-bold">자동이체</span> 설정{' '}
+              </span>
+              <Switch
+                checked={automaticTransfer}
+                onChange={setAutomaticTransfer}
+                style={{
+                  backgroundColor: automaticTransfer ? '#008485' : '#d1d5db',
+                  transform: 'scale(1.5)',
+                  transformOrigin: 'center',
+                  position: 'relative',
+                  top: '3px',
+                }}
+              />
+            </div>
+
+            {automaticTransfer && (
+              <>
+                <div className="mt-10">
+                  <p className="font-hana-regular text-3xl mb-3">
+                    <span className="font-hana-bold">
+                      매월 박스에 충전할 금액
+                    </span>
+                    을
+                    <br />
+                    입력해 주세요
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      ref={inputRef}
+                      value={monthlyAmount.toLocaleString()}
+                      onChange={handleChange}
+                      type="text"
+                      intent="green"
+                    />
+                    <span className="text-3xl font-hana-regular">원</span>
+                  </div>
+
+                  <div className="mt-10">
+                    <p className="font-hana-regular text-3xl mb-3">
+                      <span className="font-hana-bold">자동이체일</span>을
+                      입력해 주세요
+                    </p>
+                    <div className="flex gap-4 items-center">
+                      <BoxInput
+                        length={2}
+                        value={transferDay}
+                        onChange={setTransferDay}
+                        align="start"
+                      />
+                      <p className="text-3xl font-hana-regular !m-0">일</p>
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="px-6 pb-6 !mb-20">
+        <Button
+          intent="green"
+          size="lg"
+          className="w-full py-4 text-lg font-hana-bold"
+          onClick={handleSave}
+          disabled={boxName.length === 0}
+        >
+          수정
+        </Button>
+      </div>
+    </div>
   );
 };
 

--- a/src/features/wallet/types.ts
+++ b/src/features/wallet/types.ts
@@ -4,6 +4,10 @@ export interface Box {
   id: number;
   name: string;
   balance: string;
+  boxName?: string;
+  automaticTransfer?: boolean;
+  monthlyAmount?: number;
+  transferDay?: string;
 }
 
 export interface Transaction {


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #58 

## 🌱 주요 변경 사항

- 박스 수정화면 퍼블리싱을 완료했습니다.
- 기존 박스 생성 화면을 이용하되, 부모 컨테이너의 레이아웃을 수정하여 버튼이 하단에 고정되도록 변경했습니다.

## 📸 스크린샷 (선택)
<img width="335" height="817" alt="스크린샷 2025-08-31 오후 8 11 37" src="https://github.com/user-attachments/assets/bc83f651-7a6e-4ce2-ab7a-8b35b2e55879" />

<img width="332" height="825" alt="스크린샷 2025-08-31 오후 8 11 45" src="https://github.com/user-attachments/assets/3dacc5b0-e25f-4ebc-aa11-479cb84c9208" />
