### PR TITLE
fix: 박스 수정 시 자동이체일 표시 포맷(6일 → 06일) 수정

### DIFF
--- a/src/features/wallet/components/BoxEdit.tsx
+++ b/src/features/wallet/components/BoxEdit.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/features/wallet/hooks/useMainAccount';
 import type { Box } from '@/features/wallet/types';
 import { showSuccess, showError } from '@/lib/toast';
+import { formatTwoDigits } from '@/utils/numberFormat';
 
 interface BoxEditProps {
   box: Box;
@@ -47,7 +48,9 @@ const BoxEdit: React.FC<BoxEditProps> = ({ box, onBack, onSave }) => {
       setAutomaticTransfer(!!editInfo.nextAutoTransferEnabled);
       setMonthlyAmount(editInfo.nextMonthlyAmount ?? 0);
       setTransferDay(
-        editInfo.nextTransferDay != null ? String(editInfo.nextTransferDay) : ''
+        editInfo.nextTransferDay != null
+          ? formatTwoDigits(editInfo.nextTransferDay)
+          : ''
       );
       setInitialized(true);
     }

--- a/src/utils/numberFormat.ts
+++ b/src/utils/numberFormat.ts
@@ -1,0 +1,3 @@
+export const formatTwoDigits = (num: number): string => {
+  return num.toString().padStart(2, '0');
+};


### PR DESCRIPTION
## 📌 연관된 이슈 번호

- closes #124 

## 🌱 주요 변경 사항

- 박스 수정 시 자동이체일 표시 포맷(6일 → 06일) 수정 유틸함수 제작 및 적용
